### PR TITLE
Fear & Joy (WRT Toughness)

### DIFF
--- a/MoodTests.sln
+++ b/MoodTests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MoodTests", "MoodTests\MoodTests.csproj", "{85F0BB5C-0F63-4CC9-B781-F0E1158F80B2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{85F0BB5C-0F63-4CC9-B781-F0E1158F80B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85F0BB5C-0F63-4CC9-B781-F0E1158F80B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85F0BB5C-0F63-4CC9-B781-F0E1158F80B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85F0BB5C-0F63-4CC9-B781-F0E1158F80B2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2DA38E5C-AEE9-4734-B869-5167B1BAE92E}
+	EndGlobalSection
+EndGlobal

--- a/MoodTests/MoodTests.csproj
+++ b/MoodTests/MoodTests.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/MoodTests/MoodVector.cs
+++ b/MoodTests/MoodVector.cs
@@ -40,7 +40,7 @@ namespace MoodTests
         public MoodAxis Axis { get; set; }
         public List<AxisLink> LinkedRelationships { get; set; } = new List<AxisLink>();
 
-        public void LinkMood(MoodVector mood, double correlationStrength, params Correlation[] correlations)
+        public void LinkMood(MoodVector mood, params Correlation[] correlations)
         {
             if (mood.Axis == Axis || LinkedRelationships.Any(link => link.LinkedVector.Axis == mood.Axis)) return;
 
@@ -84,21 +84,21 @@ namespace MoodTests
 
     public class AxisLink
     {
-        public double StandardCorrelationFactor { get; set; }
-        public double? InvertedCorrelationFactor { get; set; }
-        public (double HighBound, double LowBound) StandardCorrelationRange { get; set; }
+        //public double StandardCorrelationFactor { get; set; }
+        //public double? InvertedCorrelationFactor { get; set; }
+        //public (double HighBound, double LowBound) StandardCorrelationRange { get; set; }
         public List<Correlation> CorrelationRanges { get; set; } = new List<Correlation>();
         public MoodVector LinkedVector { get; set; }
-        public bool IsReverseCorrelated
-        {
-            get
-            {
-                return StandardCorrelationRange.HighBound >= LinkedVector.Value || StandardCorrelationRange.LowBound <= LinkedVector.Value;
-            }
-        }
+        //public bool IsReverseCorrelated
+        //{
+        //    get
+        //    {
+        //        return StandardCorrelationRange.HighBound >= LinkedVector.Value || StandardCorrelationRange.LowBound <= LinkedVector.Value;
+        //    }
+        //}
 
-        public double CorrelationFactor => IsReverseCorrelated ? InvertedCorrelationFactor.Value : StandardCorrelationFactor;
-        public double CorrelationFactor2 => CorrelationRanges.FirstOrDefault(range => range.ContainsValue(LinkedVector.Value);
+        //public double CorrelationFactor => IsReverseCorrelated ? InvertedCorrelationFactor.Value : StandardCorrelationFactor;
+        public double CorrelationFactor2 => CorrelationRanges.FirstOrDefault(range => range.ContainsValue(LinkedVector.Value)).Factor;
         public override string ToString()
         {
             return LinkedVector.ToString();

--- a/MoodTests/MoodVector.cs
+++ b/MoodTests/MoodVector.cs
@@ -60,7 +60,7 @@ namespace MoodTests
             var modifiedDelta = delta;
             foreach (var link in LinkedRelationships)
             {
-                var correlation = link.CorrelationFactor2 * (link.LinkedVector.Value - Half); //(link.LinkedVector.Value - Half) / Max;
+                var correlation = link.CorrelationFactor2 * Math.Max(.01, link.LinkedVector.Value - Half); //(link.LinkedVector.Value - Half) / Max;
                 modifiedDelta = modifiedDelta + correlation;
             }
             Value += modifiedDelta;

--- a/MoodTests/MoodVector.cs
+++ b/MoodTests/MoodVector.cs
@@ -72,27 +72,31 @@ namespace MoodTests
 
             foreach (var link in LinkedMoods.Values)
             {
-                link.LinkedVector.UpdateMoodForPropagation(modifiedDelta, this, originalValue);
+                link.LinkedVector.UpdateMoodForPropagation(modifiedDelta, this);
             }
         }
 
-        protected void UpdateMoodForPropagation(double delta, MoodVector originatingMood, double originatingMoodValue)
+        protected void UpdateMoodForPropagation(double delta, MoodVector originatingMood)
         {
             var moodLink = LinkedMoods[originatingMood.Axis];
-            var modifiedDelta = moodLink.CorrelationFactor2 * delta;// (moodLink.LinkedVector.Value - Half); // / delta
+            var modifiedDelta = moodLink.CorrelationFactor2 / delta;// (moodLink.LinkedVector.Value - Half); // / delta
 
+            if(Math.Sign(modifiedDelta) != Math.Sign(moodLink.CorrelationFactor2)) //correlation is stronger forwards than it is in reverse
+            {
+                modifiedDelta /= 2;
+            }
 
             foreach (var link in LinkedMoods.Values)
             {
                 double correlation;
                 if (link == moodLink)
                 {
-                    correlation = link.CorrelationFactor2 * (link.LinkedVector.Value - originatingMoodValue);
+                    continue;
                 }
-                else
-                {
-                    correlation = link.CorrelationFactor2 * (link.LinkedVector.Value - Half);
-                }
+                //else
+                //{
+                correlation = link.CorrelationFactor2 * (link.LinkedVector.Value - Half);
+                //}
                 modifiedDelta = modifiedDelta + correlation;
 
             }

--- a/MoodTests/MoodVector.cs
+++ b/MoodTests/MoodVector.cs
@@ -52,6 +52,7 @@ namespace MoodTests
         {
             if (linkMood.Axis == Axis) throw new InvalidOperationException("Cant link a mood with itself. You can't land on a fraction!");
 
+            correlation.Name = $"{Axis} --> {linkMood.Axis}";
             var link = LinkedMoods.GetValueOrDefault(linkMood.Axis, new AxisLink(linkMood));
             link.CorrelationRanges.Add(correlation);
 
@@ -81,7 +82,7 @@ namespace MoodTests
             var moodLink = LinkedMoods[originatingMood.Axis];
             var modifiedDelta = moodLink.CorrelationFactor2 / delta;// (moodLink.LinkedVector.Value - Half); // / delta
 
-            if(Math.Sign(modifiedDelta) != Math.Sign(moodLink.CorrelationFactor2)) //correlation is stronger forwards than it is in reverse
+            if (Math.Sign(modifiedDelta) != Math.Sign(moodLink.CorrelationFactor2)) //correlation is stronger forwards than it is in reverse
             {
                 modifiedDelta /= 2;
             }
@@ -153,22 +154,24 @@ namespace MoodTests
             ValueLowerLimit = lowerLimitValue;
             ValueUpperLimit = upperLimitValue;
 
-            if (ValueLowerLimit > MoodVector.Half)
+            if (ValueLowerLimit > upperLimitValue)
             {
-                ValueLowerLimit = MoodVector.Half;
+                ValueLowerLimit = upperLimitValue;
             }
-            if (ValueUpperLimit < MoodVector.Half)
-            {
-                ValueUpperLimit = MoodVector.Half;
-            }
+
         }
 
+        public string Name { get; set; }
         public double Factor { get; set; }
         public double ValueUpperLimit { get; set; }
         public double ValueLowerLimit { get; set; }
         public bool ContainsValue(double value)
         {
             return ValueLowerLimit <= value && value <= ValueUpperLimit;
+        }
+        public override string ToString()
+        {
+            return $"{Name}";
         }
     }
 }

--- a/MoodTests/MoodVector.cs
+++ b/MoodTests/MoodVector.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MoodTests
+{
+    public class MoodVector
+    {
+        public MoodVector(MoodAxis axis)
+        {
+            Axis = axis;
+        }
+
+        public const double Max = 11;
+        public const double Min = 1;
+        public const double Half = (Max + Min) / 2;
+        public const double MidPositiveRange = (Max + Half) / 2;
+        public const double MidNegativeRange = (Min + Half) / 2;
+
+        private double moodValue = Half;
+        public double Value
+        {
+            get { return moodValue; }
+            set
+            {
+                if (value > Max)
+                {
+                    value = Max;
+                }
+                if (value < Min)
+                {
+                    value = Min;
+                }
+                moodValue = value;
+            }
+        }
+
+        public MoodAxis Axis { get; set; }
+        public List<AxisLink> LinkedRelationships { get; set; } = new List<AxisLink>();
+
+        public void LinkMood(MoodVector mood, double correlationStrength, params Correlation[] correlations)
+        {
+            if (mood.Axis == Axis || LinkedRelationships.Any(link => link.LinkedVector.Axis == mood.Axis)) return;
+
+            LinkedRelationships.Add(new AxisLink
+            {
+                //InvertedCorrelationFactor = invertedCorrelationFactor,
+                LinkedVector = mood,
+                CorrelationRanges = correlations.ToList()
+                //StandardCorrelationRange = standardRange,
+                //StandardCorrelationFactor = correlationStrength
+            });
+        }
+
+
+        public void UpdateMood(double delta)
+        {
+            var modifiedDelta = delta;
+            foreach (var link in LinkedRelationships)
+            {
+                var correlation = link.CorrelationFactor2 * (link.LinkedVector.Value - Half); //(link.LinkedVector.Value - Half) / Max;
+                modifiedDelta = modifiedDelta + correlation;
+            }
+            Value += modifiedDelta;
+        }
+
+        public override string ToString()
+        {
+            return $"{Axis} - {Value}";
+        }
+    }
+
+    public enum MoodAxis
+    {
+        Fear,
+        Joy,
+        Curiosity,
+        Anger,
+        Certainty,
+        Connection
+    }
+
+    public class AxisLink
+    {
+        public double StandardCorrelationFactor { get; set; }
+        public double? InvertedCorrelationFactor { get; set; }
+        public (double HighBound, double LowBound) StandardCorrelationRange { get; set; }
+        public List<Correlation> CorrelationRanges { get; set; } = new List<Correlation>();
+        public MoodVector LinkedVector { get; set; }
+        public bool IsReverseCorrelated
+        {
+            get
+            {
+                return StandardCorrelationRange.HighBound >= LinkedVector.Value || StandardCorrelationRange.LowBound <= LinkedVector.Value;
+            }
+        }
+
+        public double CorrelationFactor => IsReverseCorrelated ? InvertedCorrelationFactor.Value : StandardCorrelationFactor;
+        public double CorrelationFactor2 => CorrelationRanges.FirstOrDefault(range => range.ContainsValue(LinkedVector.Value);
+        public override string ToString()
+        {
+            return LinkedVector.ToString();
+        }
+    }
+
+    public class Correlation
+    {
+        public Correlation(double factor, double upperLimitValue, double lowerLimitValue)
+        {
+            Factor = factor;
+            ValueLowerLimit = lowerLimitValue;
+            ValueUpperLimit = upperLimitValue;
+        }
+
+        public double Factor { get; set; }
+        public double ValueUpperLimit { get; set; }
+        public double ValueLowerLimit { get; set; }
+        public bool ContainsValue(double value)
+        {
+            return ValueLowerLimit <= value && value <= ValueUpperLimit;
+        }
+    }
+}

--- a/MoodTests/Person.cs
+++ b/MoodTests/Person.cs
@@ -8,16 +8,64 @@ namespace MoodTests
 {
     public class Person
     {
-        public Person()
+        public Person(List<(TraitType type, double value)> personalityTraits)
         {
             Moods = Enum.GetValues<MoodAxis>().Select(axis => new MoodVector(axis)).ToList();
+            Traits = Enum.GetValues<TraitType>().Select(traitType =>
+                personalityTraits.Where(pts => pts.type == traitType)
+                                 .Select(traitValue => new Trait(traitValue.type, this, traitValue.value))
+                                 .FirstOrDefault(defaultValue: null) ??
+                new Trait(traitType, this, Trait.Half))
+            .ToList();
         }
 
-        public List<MoodVector> Moods { get; set; }
+        private List<MoodVector> Moods { get; set; }
+        private List<Trait> Traits { get; set; }
         public MoodVector Mood(MoodAxis axis)
         {
             return Moods.Where(m => m.Axis == axis).FirstOrDefault();
         }
 
+
+        public override string ToString()
+        {
+            string ret = "";
+            foreach (var mood in Moods)
+            {
+                ret += mood.ToString() + "\r\n";
+            }
+            return ret;
+        }
+    }
+
+    public class Trait
+    {
+        public const double Max = 5;
+        public const double Min = 1;
+        public const double Half = (Max + Min) / 2;
+        public const double MidPositiveRange = (Max + Half) / 2;
+        public const double MidNegativeRange = (Min + Half) / 2;
+
+        public TraitType TraitType { get; set; }
+        private double invertStrength(double strength)
+        {
+            return Half - strength + Half;
+        }
+
+    public enum TraitType
+    {
+        Aggression,
+        Warmth,
+        Openness,
+        Toughness,
+        Neuroticism,
+        Fearfulness
+
+    }
+
+    public enum CorrelationStrength
+    {
+        Weak,
+        Strong
     }
 }

--- a/MoodTests/Person.cs
+++ b/MoodTests/Person.cs
@@ -52,6 +52,7 @@ namespace MoodTests
             return Half - strength + Half;
         }
 
+    }
     public enum TraitType
     {
         Aggression,

--- a/MoodTests/Person.cs
+++ b/MoodTests/Person.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MoodTests
+{
+    public class Person
+    {
+        public Person()
+        {
+            Moods = Enum.GetValues<MoodAxis>().Select(axis => new MoodVector(axis)).ToList();
+        }
+
+        public List<MoodVector> Moods { get; set; }
+        public MoodVector Mood(MoodAxis axis)
+        {
+            return Moods.Where(m => m.Axis == axis).FirstOrDefault();
+        }
+
+    }
+}

--- a/MoodTests/Person.cs
+++ b/MoodTests/Person.cs
@@ -8,19 +8,17 @@ namespace MoodTests
 {
     public class Person
     {
-        public Person(List<(TraitType type, double value)> personalityTraits)
+        public List<MoodVector> Moods { get; set; }
+        public Personality Personality { get; set; }
+
+        public Person(Personality personality)
         {
             Moods = Enum.GetValues<MoodAxis>().Select(axis => new MoodVector(axis)).ToList();
-            Traits = Enum.GetValues<TraitType>().Select(traitType =>
-                personalityTraits.Where(pts => pts.type == traitType)
-                                 .Select(traitValue => new Trait(traitValue.type, this, traitValue.value))
-                                 .FirstOrDefault(defaultValue: null) ??
-                new Trait(traitType, this, Trait.Half))
-            .ToList();
+            Personality = personality;
+            Personality.LinkMoods(this);
         }
 
-        private List<MoodVector> Moods { get; set; }
-        private List<Trait> Traits { get; set; }
+
         public MoodVector Mood(MoodAxis axis)
         {
             return Moods.Where(m => m.Axis == axis).FirstOrDefault();
@@ -38,35 +36,4 @@ namespace MoodTests
         }
     }
 
-    public class Trait
-    {
-        public const double Max = 5;
-        public const double Min = 1;
-        public const double Half = (Max + Min) / 2;
-        public const double MidPositiveRange = (Max + Half) / 2;
-        public const double MidNegativeRange = (Min + Half) / 2;
-
-        public TraitType TraitType { get; set; }
-        private double invertStrength(double strength)
-        {
-            return Half - strength + Half;
-        }
-
-    }
-    public enum TraitType
-    {
-        Aggression,
-        Warmth,
-        Openness,
-        Toughness,
-        Neuroticism,
-        Fearfulness
-
-    }
-
-    public enum CorrelationStrength
-    {
-        Weak,
-        Strong
-    }
 }

--- a/MoodTests/PersonalityTrait.cs
+++ b/MoodTests/PersonalityTrait.cs
@@ -57,14 +57,21 @@ namespace MoodTests
                 case PersonalityTraitType.Toughness:
                     {
                         int thrillTerrorBoundary = (int)Math.Round(10 * (Value - Half));
-                        //boredom -fear -joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(-.005/(Value/Max), MoodVector.GetPercentOfRange(0), MoodVector.GetPercentOfRange(25)), null);
-                        //security -fear +joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(.10/(Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half), null);
-                        //thrill +fear +joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(.125/ (Value / Max), MoodVector.Half, MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary)), null);
-                        //terror +fear -joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(-.175 / (Value / Max), MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary), MoodVector.Max), null);
+                        joy.LinkMoodsBidirectional(fear, 
+                            new Correlation(-.005/(Value/Max), MoodVector.Min, MoodVector.GetPercentOfRange(25)), //boredom -joy
+                            new Correlation(.025 / (Value / Max), MoodVector.Min, MoodVector.GetPercentOfRange(25))); //despair ++fear
+
+                        joy.LinkMoodsBidirectional(fear, 
+                            new Correlation(.10/(Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half), //security -fear +joy
+                            new Correlation(.025 / (Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half)); //sadness ~+fear
+
+                        joy.LinkMoodsBidirectional(fear, 
+                            new Correlation(.125/ (Value / Max), MoodVector.Half, MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary)), //thrill +joy
+                            new Correlation(-.125 / (Value / Max), MoodVector.Half, MoodVector.MidPositiveRange)); //happiness ~-fear
+
+                        joy.LinkMoodsBidirectional(fear, 
+                            new Correlation(-.675 / (Value / Max), MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary), MoodVector.Max), //terror --joy
+                            new Correlation(-.25 / (Value / Max), MoodVector.Max, MoodVector.Max)); //joy -fear
                         break;
                     }
                 case PersonalityTraitType.Warmth:

--- a/MoodTests/PersonalityTrait.cs
+++ b/MoodTests/PersonalityTrait.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MoodTests
+{
+    public class Personality
+    {
+        public List<PersonalityTrait> Traits { get; set; } = new List<PersonalityTrait>();
+        public Personality()
+        {
+            Traits = Enum.GetValues<PersonalityTraitType>().Select(type => new PersonalityTrait(type)).ToList();
+        }
+        public PersonalityTrait Trait(PersonalityTraitType type)
+        {
+            return Traits.Where(m => m.TraitType == type).FirstOrDefault();
+        }
+
+        public void LinkMoods(Person person)
+        {
+            foreach (var trait in Traits)
+            {
+                trait.LinkMoods(person);
+            }
+        }
+    }
+
+    public class PersonalityTrait
+    {
+        public const double Max = 5;
+        public const double Min = 1;
+        public const double Half = (Max + Min) / 2;
+        public const double MidPositiveRange = (Max + Half) / 2;
+        public const double MidNegativeRange = (Min + Half) / 2;
+
+        public PersonalityTrait(PersonalityTraitType type)
+        {
+            TraitType = type;
+        }
+
+        public PersonalityTraitType TraitType { get; }
+        public double Value { get; set; }
+
+        public void LinkMoods(Person person)
+        {
+            var fear = person.Mood(MoodAxis.Fear);
+            var joy = person.Mood(MoodAxis.Joy);
+            switch (TraitType)
+            {
+                case PersonalityTraitType.Aggression:
+                    {
+                        break;
+                    }
+                case PersonalityTraitType.Toughness:
+                    {
+                        //boredom -fear -joy
+                        joy.LinkMoodsBidirectional(fear, new Correlation(-.01, MoodVector.MidNegativeRange, MoodVector.Min), null);
+                        //security -fear +joy
+                        joy.LinkMoodsBidirectional(fear, new Correlation(.20, MoodVector.Half, MoodVector.MidNegativeRange), null);
+                        //thrill +fear +joy
+                        joy.LinkMoodsBidirectional(fear, new Correlation(.25, MoodVector.MidPositiveRange, MoodVector.Half), null);
+                        //terror +fear -joy
+                        joy.LinkMoodsBidirectional(fear, new Correlation(-.35, MoodVector.Max, MoodVector.MidPositiveRange), null);
+                        break;
+                    }
+                case PersonalityTraitType.Warmth:
+                    {
+                        break;
+                    }
+                case PersonalityTraitType.Fearfulness:
+                    {
+                        break;
+                    }
+                case PersonalityTraitType.Neuroticism:
+                    {
+                        break;
+                    }
+                case PersonalityTraitType.Openness:
+                    {
+                        break;
+                    }
+            }
+        }
+    }
+
+    public enum PersonalityTraitType
+    {
+        Aggression,
+        Toughness,
+        Warmth,
+        Fearfulness,
+        Neuroticism,
+        Openness
+    }
+
+}

--- a/MoodTests/PersonalityTrait.cs
+++ b/MoodTests/PersonalityTrait.cs
@@ -42,7 +42,6 @@ namespace MoodTests
 
         public PersonalityTraitType TraitType { get; }
         public double Value { get; set; } = 3;
-        //public double ValuePercentOfScale => (Value - Half) / Max;
 
         public void LinkMoods(Person person)
         {
@@ -57,19 +56,19 @@ namespace MoodTests
                 case PersonalityTraitType.Toughness:
                     {
                         int thrillTerrorBoundary = (int)Math.Round(13 * (Value - Half));
-                        joy.LinkMoodsBidirectional(fear, 
-                            new Correlation(-.050/(Value/Max), MoodVector.Min, MoodVector.GetPercentOfRange(25)), //boredom -joy
+                        joy.LinkMoodsBidirectional(fear,
+                            new Correlation(-.050 / (Value / Max), MoodVector.Min, MoodVector.GetPercentOfRange(25)), //boredom -joy
                             new Correlation(-.400 / (Value / Max), MoodVector.Min, MoodVector.GetPercentOfRange(25))); //despair ++fear
 
-                        joy.LinkMoodsBidirectional(fear, 
-                            new Correlation(.20/(Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half), //security  +joy
+                        joy.LinkMoodsBidirectional(fear,
+                            new Correlation(.20 / (Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half), //security  +joy
                             new Correlation(-.085 / (Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half)); //sadness ~+fear
 
-                        joy.LinkMoodsBidirectional(fear, 
-                            new Correlation(.250/ (Value / Max), MoodVector.Half, MoodVector.GetPercentOfRange(70 + thrillTerrorBoundary)), //thrill +joy
+                        joy.LinkMoodsBidirectional(fear,
+                            new Correlation(.250 / (Value / Max), MoodVector.Half, MoodVector.GetPercentOfRange(70 + thrillTerrorBoundary)), //thrill +joy
                             new Correlation(-.0425 / (Value / Max), MoodVector.Half, MoodVector.MidPositiveRange)); //happiness ~-fear
 
-                        joy.LinkMoodsBidirectional(fear, 
+                        joy.LinkMoodsBidirectional(fear,
                             new Correlation(-.475 / (Value / Max), Math.Max(MoodVector.Half, MoodVector.GetPercentOfRange(70 + thrillTerrorBoundary)), MoodVector.Max), //terror --joy
                             new Correlation(-.0125 / (Value / Max), MoodVector.MidPositiveRange, MoodVector.Max)); //joy -fear
                         break;
@@ -91,11 +90,6 @@ namespace MoodTests
                         break;
                     }
             }
-        }
-
-        private double convertValueToVector()
-        {
-            return ((MoodVector.Max + MoodVector.Min) / (PersonalityTrait.Max + PersonalityTrait.Min)) * Value;
         }
     }
 

--- a/MoodTests/PersonalityTrait.cs
+++ b/MoodTests/PersonalityTrait.cs
@@ -41,7 +41,7 @@ namespace MoodTests
         }
 
         public PersonalityTraitType TraitType { get; }
-        public double Value { get; set; } = 2.1;
+        public double Value { get; set; } = 3;
         //public double ValuePercentOfScale => (Value - Half) / Max;
 
         public void LinkMoods(Person person)
@@ -56,22 +56,22 @@ namespace MoodTests
                     }
                 case PersonalityTraitType.Toughness:
                     {
-                        int thrillTerrorBoundary = (int)Math.Round(10 * (Value - Half));
+                        int thrillTerrorBoundary = (int)Math.Round(13 * (Value - Half));
                         joy.LinkMoodsBidirectional(fear, 
-                            new Correlation(-.005/(Value/Max), MoodVector.Min, MoodVector.GetPercentOfRange(25)), //boredom -joy
-                            new Correlation(.025 / (Value / Max), MoodVector.Min, MoodVector.GetPercentOfRange(25))); //despair ++fear
+                            new Correlation(-.050/(Value/Max), MoodVector.Min, MoodVector.GetPercentOfRange(25)), //boredom -joy
+                            new Correlation(-.400 / (Value / Max), MoodVector.Min, MoodVector.GetPercentOfRange(25))); //despair ++fear
 
                         joy.LinkMoodsBidirectional(fear, 
-                            new Correlation(.10/(Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half), //security -fear +joy
-                            new Correlation(.025 / (Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half)); //sadness ~+fear
+                            new Correlation(.20/(Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half), //security  +joy
+                            new Correlation(-.085 / (Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half)); //sadness ~+fear
 
                         joy.LinkMoodsBidirectional(fear, 
-                            new Correlation(.125/ (Value / Max), MoodVector.Half, MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary)), //thrill +joy
-                            new Correlation(-.125 / (Value / Max), MoodVector.Half, MoodVector.MidPositiveRange)); //happiness ~-fear
+                            new Correlation(.250/ (Value / Max), MoodVector.Half, MoodVector.GetPercentOfRange(70 + thrillTerrorBoundary)), //thrill +joy
+                            new Correlation(-.0425 / (Value / Max), MoodVector.Half, MoodVector.MidPositiveRange)); //happiness ~-fear
 
                         joy.LinkMoodsBidirectional(fear, 
-                            new Correlation(-.675 / (Value / Max), MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary), MoodVector.Max), //terror --joy
-                            new Correlation(-.25 / (Value / Max), MoodVector.Max, MoodVector.Max)); //joy -fear
+                            new Correlation(-.475 / (Value / Max), Math.Max(MoodVector.Half, MoodVector.GetPercentOfRange(70 + thrillTerrorBoundary)), MoodVector.Max), //terror --joy
+                            new Correlation(-.0125 / (Value / Max), MoodVector.MidPositiveRange, MoodVector.Max)); //joy -fear
                         break;
                     }
                 case PersonalityTraitType.Warmth:

--- a/MoodTests/PersonalityTrait.cs
+++ b/MoodTests/PersonalityTrait.cs
@@ -41,7 +41,8 @@ namespace MoodTests
         }
 
         public PersonalityTraitType TraitType { get; }
-        public double Value { get; set; }
+        public double Value { get; set; } = 2.1;
+        //public double ValuePercentOfScale => (Value - Half) / Max;
 
         public void LinkMoods(Person person)
         {
@@ -55,14 +56,15 @@ namespace MoodTests
                     }
                 case PersonalityTraitType.Toughness:
                     {
+                        int thrillTerrorBoundary = (int)Math.Round(10 * (Value - Half));
                         //boredom -fear -joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(-.01, MoodVector.MidNegativeRange, MoodVector.Min), null);
+                        joy.LinkMoodsBidirectional(fear, new Correlation(-.005/(Value/Max), MoodVector.GetPercentOfRange(0), MoodVector.GetPercentOfRange(25)), null);
                         //security -fear +joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(.20, MoodVector.Half, MoodVector.MidNegativeRange), null);
+                        joy.LinkMoodsBidirectional(fear, new Correlation(.10/(Value / Max), MoodVector.GetPercentOfRange(25), MoodVector.Half), null);
                         //thrill +fear +joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(.25, MoodVector.MidPositiveRange, MoodVector.Half), null);
+                        joy.LinkMoodsBidirectional(fear, new Correlation(.125/ (Value / Max), MoodVector.Half, MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary)), null);
                         //terror +fear -joy
-                        joy.LinkMoodsBidirectional(fear, new Correlation(-.35, MoodVector.Max, MoodVector.MidPositiveRange), null);
+                        joy.LinkMoodsBidirectional(fear, new Correlation(-.175 / (Value / Max), MoodVector.GetPercentOfRange(60 + thrillTerrorBoundary), MoodVector.Max), null);
                         break;
                     }
                 case PersonalityTraitType.Warmth:
@@ -82,6 +84,11 @@ namespace MoodTests
                         break;
                     }
             }
+        }
+
+        private double convertValueToVector()
+        {
+            return ((MoodVector.Max + MoodVector.Min) / (PersonalityTrait.Max + PersonalityTrait.Min)) * Value;
         }
     }
 

--- a/MoodTests/Program.cs
+++ b/MoodTests/Program.cs
@@ -2,19 +2,19 @@
 
 using MoodTests;
 
-var person1 = new Person();
-person1.Mood(MoodAxis.Joy).LinkMood(person1.Mood(MoodAxis.Fear), new Correlation(.15, MoodVector.MidPositiveRange, MoodVector.Half), new Correlation(-.75, MoodVector.Max, MoodVector.MidPositiveRange));
+//var person1 = new Person();
+//person1.Mood(MoodAxis.Joy).LinkMood(person1.Mood(MoodAxis.Fear), .15, (MoodVector.MidPositiveRange, MoodVector.Half), -.75);
 
 
-for (int i = 0; i < 6; i++)
-{
-    Console.WriteLine($"{person1.Mood(MoodAxis.Joy)}  {person1.Mood(MoodAxis.Fear)}");
-    person1.Mood(MoodAxis.Joy).UpdateMood(1);
-    person1.Mood(MoodAxis.Fear).UpdateMood(1);
+//for (int i = 0; i < 6; i++)
+//{
+//    Console.WriteLine($"{person1.Mood(MoodAxis.Joy)}  {person1.Mood(MoodAxis.Fear)}");
+//    person1.Mood(MoodAxis.Joy).UpdateMood(1);
+//    person1.Mood(MoodAxis.Fear).UpdateMood(1);
 
-}
+//}
 
-Console.WriteLine("\r\n\r\n\r\n");
+//Console.WriteLine("\r\n\r\n\r\n");
 
 //var person2 = new Person();
 //person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear), .15, (MoodVector.MidPositiveRange, MoodVector.Half), -.75);
@@ -27,16 +27,20 @@ Console.WriteLine("\r\n\r\n\r\n");
 //}
 
 
-var person2 = new Person();
-person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear),
-    new Correlation(-.75, MoodVector.MidPositiveRange, MoodVector.Max),
-    new Correlation(.15, MoodVector.MidPositiveRange, MoodVector.Half),
-    new Correlation(.05, MoodVector.Half, MoodVector.MidNegativeRange),
-    new Correlation(.25, MoodVector.MidNegativeRange, MoodVector.Min));
+var person2 = new Person(new Personality());
+Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
+
+
+for (int i = 0; i < 2; i++)
+{
+    person2.Mood(MoodAxis.Fear).UpdateMood(2.5);
+    Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
+    //person2.Mood(MoodAxis.Joy).UpdateMood(0);
+}
 
 for (int i = 0; i < 10; i++)
 {
-    Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
     person2.Mood(MoodAxis.Fear).UpdateMood(-1);
-    person2.Mood(MoodAxis.Joy).UpdateMood(0);
+    Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
+    //person2.Mood(MoodAxis.Joy).UpdateMood(0);
 }

--- a/MoodTests/Program.cs
+++ b/MoodTests/Program.cs
@@ -1,0 +1,38 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using MoodTests;
+
+var person1 = new Person();
+person1.Mood(MoodAxis.Joy).LinkMood(person1.Mood(MoodAxis.Fear), .15, (MoodVector.MidPositiveRange, MoodVector.Half), -.75);
+
+
+for (int i = 0; i < 6; i++)
+{
+    Console.WriteLine($"{person1.Mood(MoodAxis.Joy)}  {person1.Mood(MoodAxis.Fear)}");
+    person1.Mood(MoodAxis.Joy).UpdateMood(1);
+    person1.Mood(MoodAxis.Fear).UpdateMood(1);
+
+}
+
+Console.WriteLine("\r\n\r\n\r\n");
+
+//var person2 = new Person();
+//person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear), .15, (MoodVector.MidPositiveRange, MoodVector.Half), -.75);
+
+//for (int i = 0; i < 10; i++)
+//{
+//    Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
+//    person2.Mood(MoodAxis.Fear).UpdateMood(-1);
+//    person2.Mood(MoodAxis.Joy).UpdateMood(0);
+//}
+
+
+var person2 = new Person();
+person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear), .15, new Correlation(MoodVector.MidPositiveRange, MoodVector.Half), -.75);
+
+for (int i = 0; i < 10; i++)
+{
+    Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
+    person2.Mood(MoodAxis.Fear).UpdateMood(-1);
+    person2.Mood(MoodAxis.Joy).UpdateMood(0);
+}

--- a/MoodTests/Program.cs
+++ b/MoodTests/Program.cs
@@ -1,30 +1,5 @@
-﻿// See https://aka.ms/new-console-template for more information
-
+﻿
 using MoodTests;
-
-//var person1 = new Person();
-//person1.Mood(MoodAxis.Joy).LinkMood(person1.Mood(MoodAxis.Fear), .15, (MoodVector.MidPositiveRange, MoodVector.Half), -.75);
-
-
-//for (int i = 0; i < 6; i++)
-//{
-//    Console.WriteLine($"{person1.Mood(MoodAxis.Joy)}  {person1.Mood(MoodAxis.Fear)}");
-//    person1.Mood(MoodAxis.Joy).UpdateMood(1);
-//    person1.Mood(MoodAxis.Fear).UpdateMood(1);
-
-//}
-
-//Console.WriteLine("\r\n\r\n\r\n");
-
-//var person2 = new Person();
-//person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear), .15, (MoodVector.MidPositiveRange, MoodVector.Half), -.75);
-
-//for (int i = 0; i < 10; i++)
-//{
-//    Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
-//    person2.Mood(MoodAxis.Fear).UpdateMood(-1);
-//    person2.Mood(MoodAxis.Joy).UpdateMood(0);
-//}
 
 
 var person2 = new Person(new Personality());
@@ -35,12 +10,10 @@ for (int i = 0; i < 6; i++)
 {
     person2.Mood(MoodAxis.Fear).UpdateMood(.66);
     Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
-    //person2.Mood(MoodAxis.Joy).UpdateMood(0);
 }
 
 for (int i = 0; i < 10; i++)
 {
     person2.Mood(MoodAxis.Fear).UpdateMood(-1);
     Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
-    //person2.Mood(MoodAxis.Joy).UpdateMood(0);
 }

--- a/MoodTests/Program.cs
+++ b/MoodTests/Program.cs
@@ -29,8 +29,10 @@ Console.WriteLine("\r\n\r\n\r\n");
 
 var person2 = new Person();
 person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear),
+    new Correlation(-.75, MoodVector.MidPositiveRange, MoodVector.Max),
     new Correlation(.15, MoodVector.MidPositiveRange, MoodVector.Half),
-    new Correlation(-.75, MoodVector.Half, MoodVector.Min));
+    new Correlation(.05, MoodVector.Half, MoodVector.MidNegativeRange),
+    new Correlation(.25, MoodVector.MidNegativeRange, MoodVector.Min));
 
 for (int i = 0; i < 10; i++)
 {

--- a/MoodTests/Program.cs
+++ b/MoodTests/Program.cs
@@ -31,9 +31,9 @@ var person2 = new Person(new Personality());
 Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
 
 
-for (int i = 0; i < 2; i++)
+for (int i = 0; i < 6; i++)
 {
-    person2.Mood(MoodAxis.Fear).UpdateMood(2.5);
+    person2.Mood(MoodAxis.Fear).UpdateMood(.66);
     Console.WriteLine($"{person2.Mood(MoodAxis.Joy)}  {person2.Mood(MoodAxis.Fear)}");
     //person2.Mood(MoodAxis.Joy).UpdateMood(0);
 }

--- a/MoodTests/Program.cs
+++ b/MoodTests/Program.cs
@@ -3,7 +3,7 @@
 using MoodTests;
 
 var person1 = new Person();
-person1.Mood(MoodAxis.Joy).LinkMood(person1.Mood(MoodAxis.Fear), .15, (MoodVector.MidPositiveRange, MoodVector.Half), -.75);
+person1.Mood(MoodAxis.Joy).LinkMood(person1.Mood(MoodAxis.Fear), new Correlation(.15, MoodVector.MidPositiveRange, MoodVector.Half), new Correlation(-.75, MoodVector.Max, MoodVector.MidPositiveRange));
 
 
 for (int i = 0; i < 6; i++)
@@ -28,7 +28,9 @@ Console.WriteLine("\r\n\r\n\r\n");
 
 
 var person2 = new Person();
-person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear), .15, new Correlation(MoodVector.MidPositiveRange, MoodVector.Half), -.75);
+person2.Mood(MoodAxis.Joy).LinkMood(person2.Mood(MoodAxis.Fear),
+    new Correlation(.15, MoodVector.MidPositiveRange, MoodVector.Half),
+    new Correlation(-.75, MoodVector.Half, MoodVector.Min));
 
 for (int i = 0; i < 10; i++)
 {


### PR DESCRIPTION
A quick overview of what I have in mind just in case I'm too close to it:

The idea is that emotions/`Moods` are tracked on 6 axes, each going from 11 - 1 (where 6 is the middle), each side of the axis (11 or 1) representing a distinct maximum emotion. Those axes are 11 ---- 1:
```
Fear ------------- Safety
Joy  ------------- Sadness
Curiosity -------- Disinterest
Anger ----------- Calm
Certainty -------- Uncertainty
 Connection ----- Isolation
 ```
 Those are broadly consistent across any pet, Fear is always bad, and Joy is always good. We mediate them and join them together via `Personality Traits`, these operate on a 1-5 scale, where 3 is the middle, meaning 2.5 is Not {Trait} and 3.5 is Fairly {Trait}
 ```
 Aggression
 Warmth
 Openness
 Toughness
 Neuroticism
 Fearfulness
 ```
 Traits like `Toughness`, for instance, allow us to account for the "Horror Movie Problem" (AKA - "Why is Fear Sometimes Fun?"). In general, we link `+Fear` to `-Joy`, which is to say once the `Fear - Safety` axis crosses 6.0 into 6.1, Joy will correspondingly begin to decrease. We also assume that `Fear: 9.5` (an emotion more like terror) decreases Joy faster than `Fear 6.3` (an emotion more like a spooky goosebump).
 
`Moods` are joined on these thresholds, but the threshold is dynamic based on a given Pet's `Trait` value - if a Pet has `Toughness 1` (cowardice), we bump the terror threshold down closer to `Fear 6`, whereas if a Pet has `Toughness 5` (sociopathy?) `+Fear -> +Joy` until somewhere around 9.8.

Once these links are established, affecting any given `Mood` for a pet also has knock-on effects for its linked `Moods`, but those links also have a accelerating or mitigating effect - that is, a Pet currently at `Joy 11` will get scared slower than a Pet at `Joy 5`. This is a literal change to the impulse given for any mood. If a very happy pet is scared for `+1 Fear`, that mitigation will change it to, say `+0.85 Fear`, which means that Joy will drop slower as well.

You can test this out by pulling the code and running it, in `Program.cs` I am applying impulses to `Fear` up and down and printing out the corresponding impact that has on `Fear` and `Joy`. You can make the pet more or less brave by changing  `        public double Value { get; set; } = 3;` on line 44 in `PersonalityTrait.cs` - its currently set to dead center, and only toughness is rigged up.

**Here are some problems I see with this implementation:
1: The numbers set up in the correlation between joy/fear are pretty magical. They work, but they aren't based on anything. We can save them as consts or whatever, but there's a degree of A Wizard Did It that I can't escape because I am bad at linear algebra.

2: Setting up this one correlation between Joy and Fear took a lot of code in `public void LinkMoods(Person person)` in `PersonalityTrait.cs`. By my reckoning, there are ~18 connections across the 6 `Traits` . Its gonna get super verbose, which doesn't make this unworkable, but it does suggest that I might be missing an opportunity to pare down this logic.**
